### PR TITLE
Nullify connection only once closed, add connection debug messages

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -726,6 +726,7 @@ Client.prototype.chanData = function(name, create) {
 };
 
 Client.prototype._connectionHandler = function() {
+    this.out.debug('Socket connection successful');
     if (this.opt.webirc.ip && this.opt.webirc.pass && this.opt.webirc.host) {
         this.send('WEBIRC', this.opt.webirc.pass, this.opt.userName, this.opt.webirc.host, this.opt.webirc.ip);
     }
@@ -768,6 +769,7 @@ Client.prototype.connect = function(retryCount, callback) {
     if (self.opt.localAddress)
         connectionOpts.localAddress = self.opt.localAddress;
 
+    self.out.debug('Attempting socket connection to IRC server');
     // try to connect to the server
     if (self.opt.secure) {
         connectionOpts.rejectUnauthorized = !self.opt.selfSigned;
@@ -888,6 +890,7 @@ Client.prototype.connect = function(retryCount, callback) {
             return;
         }
 
+        self.conn = null;
         self.out.debug('Waiting ' + self.opt.retryDelay + 'ms before retrying');
         setTimeout(function() {
             self.connect(retryCount + 1);
@@ -904,7 +907,6 @@ Client.prototype.end = function() {
         this.conn.cyclingPingTimer.stop();
         this.conn.destroy();
     }
-    this.conn = null;
 };
 
 Client.prototype.disconnect = function(message, callback) {


### PR DESCRIPTION
This should fix https://github.com/reactiflux/discord-irc/issues/265 by actually having the bot reconnect when it receives a ping timeout. Before, we were accidentally discarding it too much. Whoops.

This should *not* recreate the problem fixed by b147f6c92794ec9aa7a7f66cd5c3473232712ef9, and doesn't locally.