### PR TITLE
Reorganize tests some to reduce chance of random failure

### DIFF
--- a/lib/cycling_ping_timer.js
+++ b/lib/cycling_ping_timer.js
@@ -32,7 +32,7 @@ function CyclingPingTimer(client) {
     // conditionally log debug messages
     function debug(msg) {
         if (client.opt.debug) {
-            console.error('CyclingPingTimer ' + timerNumber + ': ' + msg);
+            console.log('CyclingPingTimer ' + timerNumber + ': ' + msg);
         }
     }
 
@@ -60,6 +60,7 @@ function CyclingPingTimer(client) {
             return;
         }
         started = false;
+        debug('ping timer stopped');
 
         clearTimeout(loopingTimeout);
         clearTimeout(pingWaitTimeout);
@@ -74,6 +75,7 @@ function CyclingPingTimer(client) {
             return;
         }
         started = true;
+        debug('ping timer started');
 
         loopingTimeout = setTimeout(function() {
             loopingTimeout = null;

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -920,6 +920,7 @@ Client.prototype.disconnect = function(message, callback) {
     }
     message = message || 'node-irc says goodbye';
     var self = this;
+    self.out.debug('Disconnecting from IRC server');
     if (self.conn.readyState == 'open') {
         var sendFunction;
         if (self.opt.floodProtection) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -26,6 +26,7 @@ var MockIrcd = function(port, encoding, isSecure) {
     this.encoding = encoding || 'utf-8';
     this.incoming = [];
     this.outgoing = [];
+    console.log('Mock server initializing.');
 
     this.server = connectionClass.createServer(options, function(c) {
         var active = true;
@@ -47,6 +48,10 @@ var MockIrcd = function(port, encoding, isSecure) {
     });
 
     this.server.listen(this.port);
+
+    this.server.on('close', function(){
+        console.log('Mock server closed.');
+    })
 };
 util.inherits(MockIrcd, EventEmitter);
 
@@ -55,7 +60,7 @@ MockIrcd.prototype.send = function(data) {
 };
 
 MockIrcd.prototype.close = function() {
-    this.server.close();
+    this.server.close.apply(this.server, arguments);
 };
 
 MockIrcd.prototype.getIncomingMsgs = function() {

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -6,18 +6,6 @@ var testHelpers = require('./helpers');
 var expected = testHelpers.getFixtures('basic');
 var greeting = ':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n';
 
-test('connect, register and quit', function(t) {
-    runTests(t, false, false);
-});
-
-test('connect, register and quit, securely', function(t) {
-    runTests(t, true, false);
-});
-
-test('connect, register and quit, securely, with secure object', function(t) {
-    runTests(t, true, true);
-});
-
 function runTests(t, isSecure, useSecureObject) {
     var port = isSecure ? 6697 : 6667;
     var mock = testHelpers.MockIrcd(port, 'utf-8', isSecure);
@@ -65,9 +53,8 @@ function runTests(t, isSecure, useSecureObject) {
 }
 
 function withClient(func, conf) {
+    // closes mock server when it gets a connection end event if server used (client disconnects)
     var obj = {};
-    obj.port = 6667;
-    obj.mock = testHelpers.MockIrcd(obj.port, 'utf-8', false);
     var ircConf = {
         secure: false,
         selfSigned: true,
@@ -75,15 +62,37 @@ function withClient(func, conf) {
         retryCount: 0,
         debug: true
     };
-    if (conf) {
-        for (var prop in conf) {
-            ircConf[prop] = conf[prop];
+    if (conf) ircConf.messageSplit = conf.messageSplit;
+    if (conf && conf.withoutServer) {
+        ircConf.autoConnect = false;
+    } else {
+        var t;
+        obj.closeWithEnd = function(test) {
+            t = test;
         }
+
+        obj.port = 6667;
+        obj.mock = testHelpers.MockIrcd(obj.port, 'utf-8', false);
+        obj.mock.on('end', function() {
+            obj.mock.close(function(){ if (t) t.end(); });
+        });
     }
     obj.client = new irc.Client('localhost', 'testbot', ircConf);
 
     func(obj);
 }
+
+test('connect, register and quit', function(t) {
+    runTests(t, false, false);
+});
+
+test('connect, register and quit, securely', function(t) {
+    runTests(t, true, false);
+});
+
+test('connect, register and quit, securely, with secure object', function(t) {
+    runTests(t, true, true);
+});
 
 test ('splitting of long lines', function(t) {
     withClient(function(obj) {
@@ -93,8 +102,7 @@ test ('splitting of long lines', function(t) {
         group.forEach(function(item) {
             t.deepEqual(client._splitLongLines(item.input, item.maxLength, []), item.result);
         });
-        obj.mock.close();
-    });
+    }, { withoutServer: true });
 });
 
 test ('splitting of long lines with no maxLength defined.', function(t) {
@@ -105,24 +113,29 @@ test ('splitting of long lines with no maxLength defined.', function(t) {
         group.forEach(function(item) {
             t.deepEqual(client._splitLongLines(item.input, null, []), item.result);
         });
-        obj.mock.close();
-    });
+    }, { withoutServer: true });
 });
 
 test ('opt.messageSplit used when set', function(t) {
     withClient(function(obj) {
+        obj.closeWithEnd(t);
         var client = obj.client;
-        var group = testHelpers.getFixtures('_speak');
-        t.plan(group.length);
-        group.forEach(function(item) {
-            client.maxLineLength = item.length;
-            client._splitLongLines = function(words, maxLength, _destination) {
-                t.equal(maxLength, item.expected);
-                return [words];
-            }
-            client._speak('kind', 'target', 'test message');
+        var mock = obj.mock;
+        mock.server.on('connection', function() {
+            var group = testHelpers.getFixtures('_speak');
+            var count = 0;
+            group.forEach(function(item) {
+                client.maxLineLength = item.length;
+                client._splitLongLines = function(words, maxLength, _destination) {
+                    t.equal(maxLength, item.expected);
+                    count += 1;
+                    return [words];
+                }
+                client._speak('kind', 'target', 'test message');
+            });
+            t.equal(count, group.length, 'must test all fixtures');
+            client.disconnect();
         });
-        obj.mock.close();
     }, { messageSplit: 10 });
 });
 
@@ -134,17 +147,17 @@ test ('splits by byte with Unicode characters', function(t) {
         group.forEach(function(item) {
             t.deepEqual(client._splitLongLines(item.input, null, []), item.result);
         });
-        obj.mock.close();
-    });
+    }, { withoutServer: true });
 });
 
 test ('does not crash when disconnected and trying to send messages', function(t) {
     withClient(function(obj) {
         var client = obj.client;
         var mock = obj.mock;
+        obj.closeWithEnd(t);
 
         mock.server.on('connection', function() {
-            mock.send(':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n');
+            mock.send(greeting);
         });
 
         client.on('registered', function() {
@@ -156,11 +169,6 @@ test ('does not crash when disconnected and trying to send messages', function(t
             client.say('#channel', 'message2');
             client.end();
             client.say('#channel', 'message3');
-            t.end();
-        });
-
-        mock.on('end', function() {
-            mock.close();
         });
     });
 });

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -118,25 +118,19 @@ test ('splitting of long lines with no maxLength defined.', function(t) {
 
 test ('opt.messageSplit used when set', function(t) {
     withClient(function(obj) {
-        obj.closeWithEnd(t);
         var client = obj.client;
-        var mock = obj.mock;
-        mock.server.on('connection', function() {
-            var group = testHelpers.getFixtures('_speak');
-            var count = 0;
-            group.forEach(function(item) {
-                client.maxLineLength = item.length;
-                client._splitLongLines = function(words, maxLength, _destination) {
-                    t.equal(maxLength, item.expected);
-                    count += 1;
-                    return [words];
-                }
-                client._speak('kind', 'target', 'test message');
-            });
-            t.equal(count, group.length, 'must test all fixtures');
-            client.disconnect();
+        var group = testHelpers.getFixtures('_speak');
+        t.plan(group.length);
+        client.send = function() { };
+        group.forEach(function(item) {
+            client.maxLineLength = item.length;
+            client._splitLongLines = function(words, maxLength, _destination) {
+                t.equal(maxLength, item.expected);
+                return [words];
+            }
+            client._speak('kind', 'target', 'test message');
         });
-    }, { messageSplit: 10 });
+    }, { messageSplit: 10, withoutServer: true });
 });
 
 test ('splits by byte with Unicode characters', function(t) {


### PR DESCRIPTION
Since they were failing when I ran them on my Windows device, I tracked down the issues (mostly using `t.plan()` and then having the next test start before the previous one's server closed) and resolved them, hopefully without introducing errors into the tests on other devices.