### PR TITLE
Fix issue #19 by adding support for error 477

### DIFF
--- a/lib/codes.js
+++ b/lib/codes.js
@@ -487,6 +487,9 @@ module.exports = {
         name: 'err_badchannelkey',
         type: 'error'
     },
+    477: {
+        type: 'error'
+    },
     481: {
         name: 'err_noprivileges',
         type: 'error'

--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -46,9 +46,10 @@ module.exports = function parseMessage(line, stripColors, enableStrictParse) {
     message.commandType = 'normal';
     line = line.replace(/^[^ ]+ +/, '');
 
-    if (replyFor[message.rawCommand]) {
-        message.command     = replyFor[message.rawCommand].name;
-        message.commandType = replyFor[message.rawCommand].type;
+    var codeData = replyFor[message.rawCommand];
+    if (codeData) {
+        if ('name' in codeData) message.command = codeData.name;
+        if ('type' in codeData) message.commandType = codeData.type;
     }
 
     message.args = [];

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -127,6 +127,14 @@
 			"rawCommand": "324",
 			"commandType": "reply",
 			"args": ["nodebot", "#ubuntu", "+CLcntjf", "5:10", "#ubuntu-unregged"]
+		},
+		":127.0.0.1 477 nodebot #channel :Cannot join channel (+r) - you need to be identified with services": {
+			"prefix": "127.0.0.1",
+			"server": "127.0.0.1",
+			"command": "477",
+			"rawCommand": "477",
+			"commandType": "error",
+			"args": ["nodebot", "#channel", "Cannot join channel (+r) - you need to be identified with services"]
 		}
 	},
 	"parse-line-nonstrict": {

--- a/test/test-parse-line.js
+++ b/test/test-parse-line.js
@@ -13,9 +13,9 @@ test('irc.parseMessage', function(t) {
             delete checks[line].stripColors;
         }
         t.equal(
-            JSON.stringify(checks[line]),
             JSON.stringify(parseMessage(line, stripColors)),
-            line + ' parses correctly'
+            JSON.stringify(checks[line]),
+            line + ' must parse correctly'
         );
     });
     t.end();
@@ -26,9 +26,9 @@ test('irc.parseMessage non-strict parsing mode', function(t) {
 
     Object.keys(checks).forEach(function(line) {
         t.equal(
-            JSON.stringify(checks[line]),
             JSON.stringify(parseMessage(line, false, false)),
-            line + ' parses correctly'
+            JSON.stringify(checks[line]),
+            line + ' must parse correctly'
         );
     });
     t.end();


### PR DESCRIPTION
Sadly, according to http://defs.ircdocs.horse/defs/numerics.html#err-nochanmodes-477 it looks like error 477 has conflicting usage:

- ERR_NOCHANMODES (by RFC2812 spec)
- ERR_NEEDREGGEDNICK (with Bahamut, ircu, Unreal)

This commit allows codes to just specify a type, instead of also a name, and specifies code 477 as an error, adding a test to ensure this code is parsed as expected. This should fix #19.

It also fixes up the order of actual/expected in test-parse-line.js's t.equal calls, and makes the messages more grammatical in context (describe the test, not the success).