### PR TITLE
Fixup autorejoin on kick

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -663,8 +663,8 @@ function Client(server, nick, opt) {
         }
     });
 
-    self.addListener('kick', function(channel) {
-        if (self.opt.autoRejoin)
+    self.addListener('kick', function(channel, nick) {
+        if (self.opt.autoRejoin && nick.toLowerCase() === self.nick.toLowerCase())
             self.send.apply(self, ['JOIN'].concat(channel.split(' ')));
     });
     self.addListener('motd', function() {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -34,6 +34,7 @@ var MockIrcd = function(port, encoding, isSecure) {
         c.on('data', function(data) {
             var msg = data.toString(self.encoding).split('\r\n').filter(function(m) { return m; });
             self.incoming = self.incoming.concat(msg);
+            msg.forEach(function(line) { self.emit('line', line); });
         });
 
         self.on('send', function(data) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -68,6 +68,11 @@ MockIrcd.prototype.getIncomingMsgs = function() {
     return this.incoming;
 };
 
+MockIrcd.prototype.greet = function(username) {
+    username = username || 'testbot';
+    this.send(':localhost 001 ' + username + ' :Welcome to the Internet Relay Chat Network testbot\r\n');
+}
+
 var fixtures = require('./data/fixtures');
 module.exports.getFixtures = function(testSuite) {
     return fixtures[testSuite];

--- a/test/test-433-before-001.js
+++ b/test/test-433-before-001.js
@@ -15,7 +15,7 @@ test('connect and sets hostmask when nick in use', function(t) {
 
     mock.server.on('connection', function() {
         mock.send(':localhost 433 * testbot :Nickname is already in use.\r\n')
-        mock.send(':localhost 001 testbot1 :Welcome to the Internet Relay Chat Network testbot\r\n');
+        mock.greet('testbot1');
     });
 
     client.on('registered', function() {

--- a/test/test-auditorium.js
+++ b/test/test-auditorium.js
@@ -15,7 +15,7 @@ test('user gets opped in auditorium', function(t) {
 
     mock.server.on('connection', function() {
         // Initiate connection
-        mock.send(':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n');
+        mock.greet();
 
         // Set prefix modes
         mock.send(':localhost 005 testbot PREFIX=(ov)@+ CHANTYPES=#& :are supported by this server\r\n');

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -5,7 +5,6 @@ var testHelpers = require('./helpers');
 
 var expected = testHelpers.getFixtures('basic');
 var withClient = testHelpers.withClient;
-var greeting = ':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n';
 
 function runTests(t, isSecure, useSecureObject) {
     var port = isSecure ? 6697 : 6667;
@@ -34,9 +33,7 @@ function runTests(t, isSecure, useSecureObject) {
 
     t.plan(expected.sent.length + expected.received.length);
 
-    mock.server.on(isSecure ? 'secureConnection' : 'connection', function() {
-        mock.send(greeting);
-    });
+    mock.server.on(isSecure ? 'secureConnection' : 'connection', function() { mock.greet(); });
 
     client.on('registered', function() {
         t.equal(mock.outgoing[0], expected.received[0][0], expected.received[0][1]);
@@ -120,9 +117,7 @@ test ('does not crash when disconnected and trying to send messages', function(t
         var client = obj.client;
         var mock = obj.mock;
 
-        mock.server.on('connection', function() {
-            mock.send(greeting);
-        });
+        mock.server.on('connection', function() { mock.greet(); });
 
         client.on('registered', function() {
             client.say('#channel', 'message');
@@ -145,9 +140,7 @@ test ('unhandled messages are emitted appropriately', function(t) {
         obj.closeWithEnd(t);
         var endTimeout;
 
-        mock.server.on('connection', function() {
-            mock.send(greeting);
-        });
+        mock.server.on('connection', function(){ mock.greet(); });
 
         client.on('registered', function() {
             mock.send(':127.0.0.1 150 :test\r\n');

--- a/test/test-mode.js
+++ b/test/test-mode.js
@@ -41,9 +41,7 @@ test('handles various origins and types of chanmodes correctly', function(t) {
         { key: '#channel', serverName: '#channel', users: { testbot: '@' }, mode: '+ntbKF', modeParams: { F: [], K: [], b: ['*!*@AN.IP.1', '*!*@AN.IP.3'], n: [], t: [] } }
     ];
 
-    mock.server.on('connection', function() {
-        mock.send(':localhost 001 testbot :Welcome!\r\n');
-    });
+    mock.server.on('connection', function() { mock.greet(); });
 
     client.on('registered', function() {
         mock.send(':localhost 005 testbot MODES=12 CHANTYPES=# PREFIX=(ohv)@%+ CHANMODES=beIqa,kfL,lj,psmntirRcOAQKVCuzNSMTGHFEB\r\n');

--- a/test/test-quit.js
+++ b/test/test-quit.js
@@ -13,9 +13,7 @@ test('connect and quit with message', function(t) {
 
     t.plan(expected.sent.length + expected.received.length + 1);
 
-    mock.server.on('connection', function() {
-        mock.send(':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n');
-    });
+    mock.server.on('connection', function() { mock.greet(); });
 
     client.on('registered', function() {
         t.equal(mock.outgoing[0], expected.received[0][0], expected.received[0][1]);

--- a/test/test-reconnect.js
+++ b/test/test-reconnect.js
@@ -13,7 +13,7 @@ var testHelpers = require('./helpers');
 
         mock.server.on('connection', function(c) {
             conns.push(c);
-            mock.send(':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n');
+            mock.greet();
         });
 
         var firstTime = function() {
@@ -73,9 +73,7 @@ test('it disallows double connections', function(t) {
 
     var count = 0;
 
-    mock.server.on('connection', function() {
-        mock.send(':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n');
-    });
+    mock.server.on('connection', function() { mock.greet(); });
 
     client.on('registered', function() {
         var oldConn = client.conn;

--- a/test/test-user-events.js
+++ b/test/test-user-events.js
@@ -22,9 +22,7 @@ test('joins, parts, renicks and quits', function(t) {
     ];
     var actual = [];
 
-    mock.server.on('connection', function() {
-        mock.send(':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n');
-    });
+    mock.server.on('connection', function() { mock.greet(); });
 
     client.on('registered', function() {
         // welcome bot, give relevant prefix symbols


### PR DESCRIPTION
Make sure the bot only rejoins when it itself is kicked, instead of whenever anyone is kicked. Move the greeting used in a bunch of tests into `mock.greet(username)`. Test the rejoining process.