### PR TITLE
Add more tests

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -138,17 +138,21 @@ Client
     Sends a raw message to the server.
     Generally speaking, it's best to use other, more specific methods with priority, unless you know what you're doing.
 
-.. js:function:: Client.join(channelList, callback)
+.. js:function:: Client.join(channelList, [callback])
 
     Joins the specified channel.
 
     :param string channelList: the channel(s) to join
     :param function callback: a callback to automatically attach to `join#channelname` for each channel
 
-    ``channel`` supports multiple channels in a comma-separated string (`as in the IRC protocol <https://tools.ietf.org/html/rfc2812#page-16>`_).
+    ``channelList`` supports multiple channels in a comma-separated string (`as in the IRC protocol <https://tools.ietf.org/html/rfc2812#page-16>`_).
     The callback is called for each channel, but does not include the ``channel`` parameter (see the ``join#channel`` event).
 
-.. js:function:: Client.part(channel, [message], callback)
+    Passing ``'0'`` to the ``channelList`` parameter will send ``JOIN 0`` to the server.
+    As in the IRC spec, this will cause the client to part from all current channels.
+    In such a case, the callback will not be called; you should instead bind to the ``part`` event to keep track of the progress made.
+
+.. js:function:: Client.part(channel, [message], [callback])
 
     Parts the specified channel.
 

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -143,7 +143,7 @@ Client
     Joins the specified channel.
 
     :param string channelList: the channel(s) to join
-    :param function callback: a callback to automatically attach to `join#channelname` for each channel
+    :param function callback: an optional callback to automatically attach to ``join#channelname`` for each channel
 
     ``channelList`` supports multiple channels in a comma-separated string (`as in the IRC protocol <https://tools.ietf.org/html/rfc2812#page-16>`_).
     The callback is called for each channel, but does not include the ``channel`` parameter (see the ``join#channel`` event).
@@ -156,9 +156,11 @@ Client
 
     Parts the specified channel.
 
-    :param string channel: the channel to part
+    :param string channelList: the channel(s) to part
     :param string message: an optional message to send upon leaving the channel
-    :param function callback: a callback to run once the bot has parted the channel
+    :param function callback: a optional callback to automatically attach to ``part#channelname`` for each channel
+
+    As with ``Client.join``, the ``channelList`` parameter supports multiple channels in a comma-separated string, for each of which the callback will be called.
 
 .. js:function:: Client.say(target, message)
 

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -130,7 +130,7 @@ Client
     If ``message`` is a function it will be treated as a ``callback`` (i.e. both arguments to this function are optional).
     Outputs an error to console if it is already disconnected or disconnecting.
 
-    :param string message: an optional message to send when disconnecting.
+    :param string message: an optional message to send when disconnecting
     :param function callback: an optional callback
 
 .. js:function:: Client.send(command, arg1, arg2, ...)
@@ -138,14 +138,15 @@ Client
     Sends a raw message to the server.
     Generally speaking, it's best to use other, more specific methods with priority, unless you know what you're doing.
 
-.. js:function:: Client.join(channel, callback)
+.. js:function:: Client.join(channelList, callback)
 
     Joins the specified channel.
 
-    :param string channel: the channel to join
-    :param function callback: a callback to run once the bot has joined the channel.
+    :param string channelList: the channel(s) to join
+    :param function callback: a callback to automatically attach to `join#channelname` for each channel
 
-    ``channel`` supports multiple arguments in a space-separated string (as in the IRC protocol).
+    ``channel`` supports multiple channels in a comma-separated string (`as in the IRC protocol <https://tools.ietf.org/html/rfc2812#page-16>`_).
+    The callback is called for each channel, but does not include the ``channel`` parameter (see the ``join#channel`` event).
 
 .. js:function:: Client.part(channel, [message], callback)
 
@@ -153,7 +154,7 @@ Client
 
     :param string channel: the channel to part
     :param string message: an optional message to send upon leaving the channel
-    :param function callback: a callback to run once the bot has parted the channel.
+    :param function callback: a callback to run once the bot has parted the channel
 
 .. js:function:: Client.say(target, message)
 

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -346,6 +346,8 @@ Events
     ``function (nick, reason, channels, message) { }``
 
     Emitted when a user disconnects from the IRC server, leaving the specified array of channels.
+    Channels are emitted case-lowered.
+
     See the ``raw`` event for details on the ``message`` object.
 
 .. js:data:: 'kick'
@@ -368,6 +370,8 @@ Events
 
     Emitted when a user is killed from the IRC server.
     The ``channels`` parameter is an array of channels the killed user was in, those known to the client (that is, the ones the bot was present in).
+    Channels are emitted case-lowered.
+
     See the ``raw`` event for details on the ``message`` object.
 
 .. js:data:: 'nick'
@@ -375,6 +379,8 @@ Events
     ``function (oldnick, newnick, channels, message) { }``
 
     Emitted when a user changes nick, with the channels the user is known to be in.
+    Channels are emitted case-lowered.
+
     See the ``raw`` event for details on the ``message`` object.
 
 .. js:data:: '+mode'

--- a/lib/cycling_ping_timer.js
+++ b/lib/cycling_ping_timer.js
@@ -4,15 +4,11 @@ var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 
 /**
- * This class encapsulates the ping timeout functionality. When enough
- * silence (lack of server-sent activity) time passes, an object of this type
- * will emit a 'wantPing' event, indicating you should send a PING message
- * to the server in order to get some signs of life from it. If enough
- * time passes after that (i.e. server does not respond to PING), then
- * an object of this type will emit a 'pingTimeout' event.
+ * This class encapsulates the ping timeout functionality.
+ * When enough silence (lack of server-sent activity) passes, an object of this type will emit a 'wantPing' event, indicating you should send a PING message to the server in order to get some signs of life from it.
+ * If enough time passes after that (i.e. server does not respond to PING), then an object of this type will emit a 'pingTimeout' event.
  *
- * To start the gears turning, call start() on an instance of this class To
- * put it in the 'started' state.
+ * To start the gears turning, call start() on an instance of this class to put it in the 'started' state.
  *
  * When server-side activity occurs, call notifyOfActivity() on the object.
  *

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -876,7 +876,7 @@ Client.prototype.connect = function(retryCount, callback) {
                     self.emit('raw', message);
                 } catch (err) {
                     if (!self.conn.requestedDisconnect) {
-                        throw err;
+                        self.emit('error', err);
                     }
                 }
             }

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -425,8 +425,7 @@ function Client(server, clientNick, opt) {
             case 'rpl_endofnames':
                 channel = self.chanData(message.args[1]);
                 if (channel) {
-                    self.emit('names', message.args[1], channel.users);
-                    self.emit('names' + message.args[1], channel.users);
+                    self.emitChannelEvent('names', message.args[1], channel.users);
                     self.send('MODE', message.args[1]);
                 }
                 break;
@@ -523,31 +522,21 @@ function Client(server, clientNick, opt) {
                 // channel, who
                 if (self.nick === message.nick) {
                     self.chanData(message.args[0], true);
-                }
-                else {
+                } else {
                     channel = self.chanData(message.args[0]);
                     if (channel && channel.users) {
                         channel.users[message.nick] = '';
                     }
                 }
-                self.emit('join', message.args[0], message.nick, message);
-                self.emit('join' + message.args[0], message.nick, message);
-                if (message.args[0] !== message.args[0].toLowerCase()) {
-                    self.emit('join' + message.args[0].toLowerCase(), message.nick, message);
-                }
+                self.emitChannelEvent('join', message.args[0], message.nick, message);
                 break;
             case 'PART':
                 // channel, who, reason
-                self.emit('part', message.args[0], message.nick, message.args[1], message);
-                self.emit('part' + message.args[0], message.nick, message.args[1], message);
-                if (message.args[0] !== message.args[0].toLowerCase()) {
-                    self.emit('part' + message.args[0].toLowerCase(), message.nick, message.args[1], message);
-                }
+                self.emitChannelEvent('part', message.args[0], message.nick, message.args[1], message);
                 if (self.nick === message.nick) {
                     channel = self.chanData(message.args[0]);
                     delete self.chans[channel.key];
-                }
-                else {
+                } else {
                     channel = self.chanData(message.args[0]);
                     if (channel && channel.users) {
                         delete channel.users[message.nick];
@@ -556,18 +545,12 @@ function Client(server, clientNick, opt) {
                 break;
             case 'KICK':
                 // channel, who, by, reason
-                self.emit('kick', message.args[0], message.args[1], message.nick, message.args[2], message);
-                self.emit('kick' + message.args[0], message.args[1], message.nick, message.args[2], message);
-                if (message.args[0] !== message.args[0].toLowerCase()) {
-                    self.emit('kick' + message.args[0].toLowerCase(),
-                        message.args[1], message.nick, message.args[2], message);
-                }
+                self.emitChannelEvent('kick', message.args[0], message.args[1], message.nick, message.args[2], message);
 
                 if (self.nick === message.args[1]) {
                     channel = self.chanData(message.args[0]);
                     delete self.chans[channel.key];
-                }
-                else {
+                } else {
                     channel = self.chanData(message.args[0]);
                     if (channel && channel.users) {
                         delete channel.users[message.args[1]];
@@ -677,8 +660,7 @@ function Client(server, clientNick, opt) {
                 if (message.commandType === 'error') {
                     self.out.error(message);
                     self.emit('error', message);
-                }
-                else {
+                } else {
                     self.out.error('Unhandled message:', message);
                     self.emit('unhandled', message);
                     break;
@@ -1155,6 +1137,16 @@ Client.prototype.say = function(target, text) {
 
 Client.prototype.notice = function(target, text) {
     this._speak('NOTICE', target, text);
+};
+
+Client.prototype.emitChannelEvent = function(eventName, channel) {
+    var args = Array.prototype.slice.call(arguments, 2);
+    console.log('emitting for:', eventName, channel);
+    this.emit.apply(this, [eventName, channel].concat(args));
+    this.emit.apply(this, [eventName + channel].concat(args));
+    if (channel !== channel.toLowerCase()) {
+      this.emit.apply(this, [eventName + channel.toLowerCase()].concat(args));
+    }
 };
 
 Client.prototype._speak = function(kind, target, text) {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -671,11 +671,11 @@ function Client(server, clientNick, opt) {
 
     self.addListener('kick', function(channel, nick) {
         if (self.opt.autoRejoin && nick.toLowerCase() === self.nick.toLowerCase())
-            self.send.apply(self, ['JOIN'].concat(channel.split(' ')));
+            self.send('JOIN', channel);
     });
     self.addListener('motd', function() {
         self.opt.channels.forEach(function(channel) {
-            self.send.apply(self, ['JOIN'].concat(channel.split(' ')));
+            self.send('JOIN', channel);
         });
     });
 
@@ -1041,19 +1041,22 @@ Client.prototype.cancelAutoRenick = function() {
     return oldInterval;
 };
 
-Client.prototype.join = function(channel, callback) {
-    var channelName = channel.split(' ')[0];
-    this.once('join' + channelName.toLowerCase(), function() {
-        // Append to opts.channel on successful join, so it rejoins on reconnect.
-        if (this.opt.channels.indexOf(channel) === -1) {
-            this.opt.channels.push(channel);
-        }
+Client.prototype.join = function(channelList, callback) {
+    var self = this;
+    var channels = channelList.split(',');
+    channels.forEach(function(channelName) {
+        self.once('join' + channelName.toLowerCase(), function() {
+            // Append to opts.channel on successful join, so it rejoins on reconnect.
+            if (self.opt.channels.indexOf(channelName) === -1) {
+                self.opt.channels.push(channelName);
+            }
 
-        if (typeof callback === 'function') {
-            return callback.apply(this, arguments);
-        }
+            if (typeof callback === 'function') {
+                return callback.apply(this, arguments);
+            }
+        });
     });
-    this.send.apply(this, ['JOIN'].concat(channel.split(' ')));
+    self.send('JOIN', channelList);
 };
 
 Client.prototype.part = function(channel, message, callback) {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1042,9 +1042,9 @@ Client.prototype.cancelAutoRenick = function() {
 };
 
 Client.prototype.join = function(channel, callback) {
-    var channelName =  channel.split(' ')[0];
-    this.once('join' + channelName, function() {
-        // Append to opts.channel on successfuly join, so it rejoins on reconnect.
+    var channelName = channel.split(' ')[0];
+    this.once('join' + channelName.toLowerCase(), function() {
+        // Append to opts.channel on successful join, so it rejoins on reconnect.
         if (this.opt.channels.indexOf(channel) === -1) {
             this.opt.channels.push(channel);
         }

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1142,7 +1142,6 @@ Client.prototype.notice = function(target, text) {
 
 Client.prototype.emitChannelEvent = function(eventName, channel) {
     var args = Array.prototype.slice.call(arguments, 2);
-    console.log('emitting for:', eventName, channel);
     this.emit.apply(this, [eventName, channel].concat(args));
     this.emit.apply(this, [eventName + channel].concat(args));
     if (channel !== channel.toLowerCase()) {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -586,10 +586,10 @@ function Client(server, clientNick, opt) {
                         self.emit('message' + to.toLowerCase(), from, text, message);
                     }
                 }
-                if (to.toUpperCase() === self.nick.toUpperCase()) self.emit('pm', from, text, message);
-
-                if (to === self.nick)
-                    self.out.debug('GOT MESSAGE from ' + from + ': ' + text);
+                if (to.toUpperCase() === self.nick.toUpperCase()) {
+                    self.emit('pm', from, text, message);
+                    self.out.debug('GOT MESSAGE from "' + from + '": "' + text + '"');
+                }
                 break;
             case 'INVITE':
                 from = message.nick;

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -246,7 +246,7 @@ function Client(server, clientNick, opt) {
             case 'err_nicknameinuse':
                 if (typeof self.opt.nickMod === 'undefined')
                     self.opt.nickMod = 0;
-                if (message.args[1] === self.opt.nick && self.conn.renickInterval) {
+                if (message.args[1] === self.opt.nick && (self.conn.renickInterval || self.conn.attemptedLastRenick)) {
                     self.out.debug('Attempted to automatically renick to', message.args[1], 'and found it taken');
                     break;
                 }
@@ -268,6 +268,7 @@ function Client(server, clientNick, opt) {
                         if (self.opt.renickCount !== null && renickTimes >= self.opt.renickCount) {
                             self.out.debug('Maximum autorenick retry count (' + self.opt.renickCount + ') reached');
                             self.cancelAutoRenick();
+                            self.conn.attemptedLastRenick = true;
                         }
                     }, self.opt.renickDelay);
                 }

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1059,24 +1059,28 @@ Client.prototype.join = function(channelList, callback) {
     self.send('JOIN', channelList);
 };
 
-Client.prototype.part = function(channel, message, callback) {
+Client.prototype.part = function(channelList, message, callback) {
     if (typeof (message) === 'function') {
         callback = message;
         message = undefined;
     }
-    if (typeof callback === 'function') {
-        this.once('part' + channel, callback);
-    }
+    var self = this;
+    var channels = channelList.split(',');
+    channels.forEach(function(channelName) {
+      if (typeof callback === 'function') {
+          self.once('part' + channelName.toLowerCase(), callback);
+      }
 
-    // remove this channel from this.opt.channels so we won't rejoin upon reconnect
-    if (this.opt.channels.indexOf(channel) !== -1) {
-        this.opt.channels.splice(this.opt.channels.indexOf(channel), 1);
-    }
+      // remove this channel from this.opt.channels so we won't rejoin upon reconnect
+      if (self.opt.channels.indexOf(channelName) !== -1) {
+          self.opt.channels.splice(self.opt.channels.indexOf(channelName), 1);
+      }
+    });
 
     if (message) {
-        this.send('PART', channel, message);
+        this.send('PART', channelList, message);
     } else {
-        this.send('PART', channel);
+        this.send('PART', channelList);
     }
 };
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -245,3 +245,30 @@ module.exports.hookMockSetup = function hookMockSetup(beforeEach, afterEach, con
     teardownMocks({client: this.client, mock: this.mock}, done);
   });
 };
+
+function joinChannels(local, localChannels, remoteChannels, done) {
+  var i = 0;
+  local.client.on('join', function() {
+    i++;
+    if (i === localChannels.length) {
+      setTimeout(function() {
+        if (local.debugSpy) local.debugSpy.reset();
+        if (local.sendSpy) local.sendSpy.reset();
+        done();
+      }, 10);
+    }
+  });
+  localChannels.forEach(function(chan) {
+    local.client.join(chan);
+  });
+  remoteChannels.forEach(function(remoteChan) {
+    local.mock.send(':testbot!~testbot@EXAMPLE.HOST JOIN :' + remoteChan + '\r\n');
+  });
+}
+module.exports.joinChannels = joinChannels;
+
+module.exports.joinChannelsBefore = function (beforeEach, localChannels, remoteChannels) {
+  beforeEach(function(done) {
+    joinChannels(this, localChannels, remoteChannels, done);
+  });
+};

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -106,7 +106,7 @@ module.exports.MockPingTimer = function() {
   return new MockPingTimer();
 };
 
-var ircWithPingStub = proxyquire('../lib/irc', {util: stubbedUtil, './cycling_ping_timer.js': MockPingTimer})
+var ircWithPingStub = proxyquire('../lib/irc', {util: stubbedUtil, './cycling_ping_timer.js': MockPingTimer});
 
 function setupMocks(config, callback) {
   // both args optional

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -5,15 +5,13 @@ var fs = require('fs');
 var net = require('net');
 var tls = require('tls');
 var util = require('util');
-var irc = require('../lib/irc');
 var EventEmitter = require('events').EventEmitter;
 var sinon = require('sinon');
 var proxyquire = require('proxyquire');
-var stubbedUtil = {log: function(){}};
-var ircWithStubbedOutput = proxyquire('../lib/irc', {util: stubbedUtil});
+var stubbedUtil = {log: null};
+var irc = proxyquire('../lib/irc', {util: stubbedUtil});
 
-module.exports.irc = irc;
-module.exports.ircWithStubbedOutput = ircWithStubbedOutput;
+module.exports.ircWithStubbedOutput = irc;
 
 var MockIrcd = function(port, encoding, isSecure, quiet) {
     var self = this;
@@ -87,8 +85,28 @@ module.exports.getFixtures = function(testSuite) {
 };
 
 module.exports.MockIrcd = function(port, encoding, isSecure, quiet) {
-    return new MockIrcd(port, encoding, isSecure, quiet);
+  return new MockIrcd(port, encoding, isSecure, quiet);
 };
+
+var pingTimerStubs = {
+  notifyOfActivity: sinon.stub(),
+  stop: sinon.stub(),
+  start: sinon.stub()
+};
+
+var MockPingTimer = function() {
+  for (var key in pingTimerStubs) {
+    pingTimerStubs[key].reset();
+  }
+  Object.assign(this, pingTimerStubs);
+};
+util.inherits(MockPingTimer, EventEmitter);
+
+module.exports.MockPingTimer = function() {
+  return new MockPingTimer();
+};
+
+var ircWithPingStub = proxyquire('../lib/irc', {util: stubbedUtil, './cycling_ping_timer.js': MockPingTimer})
 
 function setupMocks(config, callback) {
   // both args optional
@@ -99,6 +117,7 @@ function setupMocks(config, callback) {
   // - callbackEarly (default false): calls callback when initialization finished instead ofon  client registered event
   // - disableOutput (default true): stubs client's util.log to reduce output clutter
   // - withoutServer (default false): skips server, makes client not autoConnect by default and enables callbackEarly
+  // - stubTimer (default false): stubs the cyclingPingTimer
 
   if (typeof callback === 'undefined' && typeof config === 'function') { callback = config; config = undefined; }
   config = config || {};
@@ -106,7 +125,7 @@ function setupMocks(config, callback) {
   config.client = config.client || {};
   config.server = config.server || {};
 
-  var defaultMeta = {autoGreet: true, callbackEarly: false, disableOutput: true, withoutServer: false};
+  var defaultMeta = {autoGreet: true, callbackEarly: false, disableOutput: true, withoutServer: false, stubTimer: false};
   var defaultClient = {debug: true};
   var defaultServer = {};
 
@@ -120,16 +139,19 @@ function setupMocks(config, callback) {
   var serverConfig = Object.assign(defaultServer, config.server);
 
   var quiet = metaConfig.disableOutput;
+  var stubTimer = metaConfig.stubTimer;
 
-  var lineSpy;
-  var mock;
+  var mockObj = {};
+
   if (!metaConfig.withoutServer) {
-    lineSpy = sinon.spy();
-    mock = module.exports.MockIrcd(serverConfig.port, serverConfig.encoding, serverConfig.isSecure, quiet);
+    var lineSpy = sinon.spy();
+    var mock = module.exports.MockIrcd(serverConfig.port, serverConfig.encoding, serverConfig.isSecure, quiet);
     mock.on('line', lineSpy);
     mock.server.on('connection', function() {
       if (metaConfig.autoGreet) mock.greet();
     });
+    mockObj.mock = mock;
+    mockObj.lineSpy = lineSpy;
   }
 
   var clientServer = 'localhost';
@@ -143,10 +165,19 @@ function setupMocks(config, callback) {
     delete clientConfig.nick;
   }
 
-  var lib = (quiet) ? ircWithStubbedOutput : irc;
+  if (quiet) {
+    stubbedUtil.log = sinon.stub();
+  } else {
+    stubbedUtil.log = util.log.bind(util);
+  }
+  var lib = irc;
+  if (stubTimer) {
+    lib = ircWithPingStub;
+    mockObj.pingTimerStubs = pingTimerStubs;
+  }
   var client = new lib.Client(clientServer, clientNick, clientConfig);
+  mockObj.client = client;
 
-  var mockObj = {mock: mock, client: client, lineSpy: lineSpy};
   client.once('registered', function() {
     if (!metaConfig.callbackEarly) callback(mockObj);
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -63,7 +63,11 @@ var MockIrcd = function(port, encoding, isSecure, quiet) {
 util.inherits(MockIrcd, EventEmitter);
 
 MockIrcd.prototype.send = function(data) {
-    this.emit('send', data);
+  if (data.slice(-2) !== '\r\n') {
+    console.log("WARNING: mock.send called without trailing \\r\\n");
+    console.log("data:", data);
+  }
+  this.emit('send', data);
 };
 
 MockIrcd.prototype.close = function() {

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -1,5 +1,6 @@
 var testHelpers = require('./helpers');
 var itWithCustomMock = testHelpers.itWithCustomMock;
+var joinChannelsBefore = testHelpers.joinChannelsBefore;
 var chai = require('chai');
 var expect = chai.expect;
 var sinon = require('sinon');
@@ -114,29 +115,6 @@ describe('Client', function() {
       ]);
     });
   });
-
-  function joinChannelsBefore(beforeEach, localChannels, remoteChannels) {
-    beforeEach(function(done) {
-      var self = this;
-      var i = 0;
-      self.client.on('join', function() {
-        i++;
-        if (i === localChannels.length) {
-          setTimeout(function() {
-            self.debugSpy.reset();
-            self.sendSpy.reset();
-            done();
-          }, 10);
-        }
-      });
-      localChannels.forEach(function(chan) {
-        self.client.join(chan);
-      });
-      remoteChannels.forEach(function(remoteChan) {
-        self.mock.send(':testbot!~testbot@EXAMPLE.HOST JOIN :' + remoteChan + '\r\n');
-      });
-    });
-  }
 
   describe('#join', function() {
     testHelpers.hookMockSetup(beforeEach, afterEach);

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -1,0 +1,35 @@
+var testHelpers = require('./helpers');
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
+
+describe('Client', function() {
+  describe('raw handler', function() {
+    testHelpers.hookMockSetup(beforeEach, afterEach);
+    it('throws if an error occurs and no error handler is bound', function() {
+      var self = this;
+      function wrap() {
+        self.client.conn.emit('data', ':127.0.0.1 PING :1\r\n');
+      }
+      self.client.on('raw', function() {
+        throw new Error('test error');
+      });
+      expect(wrap).to.throw(Error, 'test error');
+    });
+
+    it('passes error to error handler if bound', function() {
+      var self = this;
+      var errorSpy = sinon.spy();
+      var error = new Error('test error');
+      function wrap() {
+        self.client.conn.emit('data', ':127.0.0.1 PING :1\r\n');
+      }
+      self.client.on('raw', function() {
+        throw error;
+      });
+      self.client.on('error', errorSpy);
+      expect(wrap).not.to.throw();
+      expect(errorSpy.args).to.deep.equal([[error]]);
+    });
+  });
+});

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -1,4 +1,5 @@
 var testHelpers = require('./helpers');
+var itWithCustomMock = testHelpers.itWithCustomMock;
 var chai = require('chai');
 var expect = chai.expect;
 var sinon = require('sinon');
@@ -30,6 +31,77 @@ describe('Client', function() {
       self.client.on('error', errorSpy);
       expect(wrap).not.to.throw();
       expect(errorSpy.args).to.deep.equal([[error]]);
+    });
+  });
+
+  describe('#send', function() {
+    testHelpers.hookMockSetup(beforeEach, afterEach);
+
+    beforeEach(function() {
+      this.debugSpy = sinon.spy();
+      this.connSpy = sinon.spy();
+      this.client.out.debug = this.debugSpy;
+      this.client.conn.write = this.connSpy;
+    });
+
+    it('works with simple data', function() {
+      this.client.send('JOIN', '#channel');
+      expect(this.debugSpy.args).to.deep.equal([
+        ['SEND:', 'JOIN #channel']
+      ]);
+      expect(this.connSpy.args).to.deep.equal([
+        ['JOIN #channel\r\n']
+      ]);
+    });
+
+    it('works with multiple arguments', function() {
+      this.client.send('TEST', 'example', 'data');
+      expect(this.debugSpy.args).to.deep.equal([
+        ['SEND:', 'TEST example data']
+      ]);
+      expect(this.connSpy.args).to.deep.equal([
+        ['TEST example data\r\n']
+      ]);
+    });
+
+    it('works with multi-word last parameter', function() {
+      this.client.send('TEST', 'example data');
+      expect(this.debugSpy.args).to.deep.equal([
+        ['SEND:', 'TEST :example data']
+      ]);
+      expect(this.connSpy.args).to.deep.equal([
+        ['TEST :example data\r\n']
+      ]);
+    });
+
+    itWithCustomMock('does not throw when disconnected',
+    {meta: {withoutServer: true}},
+    function() {
+      var self = this;
+      self.debugSpy = sinon.spy();
+      self.client.out.debug = self.debugSpy;
+      function wrap() {
+        self.client.send('TEST', 'example data');
+      }
+      expect(wrap).not.to.throw();
+      expect(self.debugSpy.args).to.deep.equal([
+        ['(Disconnected) SEND:', 'TEST :example data']
+      ]);
+    });
+
+    it('does not throw when disconnecting', function() {
+      var self = this;
+      function wrap() {
+        self.client.disconnect();
+        self.client.send('TEST', 'example data');
+      }
+      expect(wrap).not.to.throw();
+      expect(self.debugSpy.args).to.deep.include([
+        '(Disconnected) SEND:', 'TEST :example data'
+      ]);
+      expect(self.connSpy.args).to.deep.equal([
+        ['QUIT :node-irc says goodbye\r\n']
+      ]);
     });
   });
 });

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -104,4 +104,85 @@ describe('Client', function() {
       ]);
     });
   });
+
+  describe('#join', function() {
+    testHelpers.hookMockSetup(beforeEach, afterEach);
+
+    beforeEach(function(done) {
+      var self = this;
+      setTimeout(function() {
+        self.debugSpy = sinon.spy();
+        self.sendSpy = sinon.spy();
+        self.client.out.debug = self.debugSpy;
+        self.client.send = self.sendSpy;
+        done();
+      }, 10);
+    });
+
+    function sharedExamplesFor(channel, remoteChannel) {
+      function downcaseChannels(channels) {
+        return channels.map(function(x) { return x.toLowerCase(); });
+      }
+
+      it('works with given channel', function() {
+        this.client.join(channel);
+        expect(this.sendSpy.args).to.deep.equal([
+          ['JOIN', channel]
+        ]);
+      });
+
+      it('adds to opt.channels on successful join', function(done) {
+        var self = this;
+        self.client.on('join', function() {
+          setTimeout(check, 10);
+        });
+        expect(self.client.opt.channels).to.be.empty;
+        self.client.join(channel);
+        this.mock.send(':testbot!~testbot@EXAMPLE.HOST JOIN :' + remoteChannel + '\r\n');
+
+        function check() {
+          expect(downcaseChannels(self.client.opt.channels)).to.deep.equal([channel.toLowerCase()]);
+          done();
+        }
+      });
+
+      it('calls given callback', function(done) {
+        var self = this;
+        expect(self.client.opt.channels).to.be.empty;
+        self.client.join(channel, check);
+        this.mock.send(':testbot!~testbot@EXAMPLE.HOST JOIN :' + remoteChannel + '\r\n');
+
+        function check(nick, message) {
+          expect(nick).to.equal('testbot');
+          expect(message).to.deep.equal({
+            prefix: 'testbot!~testbot@EXAMPLE.HOST',
+            nick: 'testbot',
+            user: '~testbot',
+            host: 'EXAMPLE.HOST',
+            commandType: 'normal',
+            command: 'JOIN',
+            rawCommand: 'JOIN',
+            args: [remoteChannel]
+          });
+          done();
+        }
+      });
+    }
+
+    context('with same lowercase local and remote channel', function() {
+      sharedExamplesFor('#channel', '#channel');
+    });
+
+    context('with same mixed-case local and remote channel', function() {
+      sharedExamplesFor('#Channel', '#Channel');
+    });
+
+    context('with mixed-case local channel differing from lowercase remote channel', function() {
+      sharedExamplesFor('#Channel', '#channel');
+    });
+
+    context('with lowercase local channel differing from mixed-case remote channel', function() {
+      sharedExamplesFor('#channel', '#Channel');
+    });
+  });
 });

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -74,6 +74,16 @@ describe('Client', function() {
       ]);
     });
 
+    it('works with comma-separated channel example', function() {
+      this.client.send('PART', '#channel1,#channel2,#channel3', 'test message');
+      expect(this.debugSpy.args).to.deep.equal([
+        ['SEND:', 'PART #channel1,#channel2,#channel3 :test message']
+      ]);
+      expect(this.connSpy.args).to.deep.equal([
+        ['PART #channel1,#channel2,#channel3 :test message\r\n']
+      ]);
+    });
+
     itWithCustomMock('does not throw when disconnected',
     {meta: {withoutServer: true}},
     function() {

--- a/test/test-convert-encoding.js
+++ b/test/test-convert-encoding.js
@@ -20,7 +20,7 @@ describe('Client', function() {
           var wrap = function() {
             client.convertEncoding(line);
           };
-          expect(wrap).not.to.throw;
+          expect(wrap).not.to.throw();
         });
       });
     });
@@ -39,7 +39,7 @@ describe('Client', function() {
           var wrap = function() {
             client.convertEncoding(line);
           };
-          expect(wrap).not.to.throw;
+          expect(wrap).not.to.throw();
         });
       });
 

--- a/test/test-convert-encoding.js
+++ b/test/test-convert-encoding.js
@@ -26,9 +26,23 @@ describe('Client', function() {
     });
 
     context('with proper node-icu-charset-detector and iconv', function() {
-      // TODO: skip if cannot require
+      testHelpers.hookMockSetup(beforeEach, afterEach);
+      beforeEach(function() {
+        if (!this.client.canConvertEncoding()) this.skip();
+      });
+
       it('works with valid data');
-      it('does not throw with sample data');
+
+      it('does not throw with sample data', function() {
+        var client = this.client;
+        checks.causesException.forEach(function(line) {
+          var wrap = function() {
+            client.convertEncoding(line);
+          };
+          expect(wrap).not.to.throw;
+        });
+      });
+
       it('does not throw with invalid data');
     });
   });

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -220,7 +220,29 @@ describe('Client', function() {
     });
   });
 
-  it('emits error events properly');
+  describe('errors', function() {
+    testHelpers.hookMockSetup(beforeEach, afterEach, {client: {server: '127.0.0.1'}});
+    specify('are emitted appropriately', function(done) {
+      var mock = this.mock;
+      var client = this.client;
+
+      client.on('error', function(msg) {
+        var expected = {
+          prefix: '127.0.0.1',
+          server: '127.0.0.1',
+          rawCommand: '421',
+          command: 'err_unknowncommand',
+          commandType: 'error',
+          args: ['testbot', 'test', 'Unknown command']
+        };
+        expect(msg).to.deep.equal(expected);
+        done();
+      });
+
+      client.send('test');
+      mock.send(':127.0.0.1 421 testbot test :Unknown command\r\n');
+    });
+  });
 
   itWithCustomMock('does not crash when disconnected and sending messages',
   {meta: {withoutServer: true}},

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -8,12 +8,14 @@ var sinon = require('sinon');
 describe('Client', function() {
   describe('connect', function() {
     context('with standard greeting', function() {
-      function runTests(done, isSecure, useSecureObject) {
+      function runTests(done, isSecure, useSecureObject, skipObject) {
         var expected = testHelpers.getFixtures('basic');
         var port = isSecure ? 6697 : 6667;
         var mock = testHelpers.MockIrcd(port, 'utf-8', isSecure, true);
         var client;
-        if (isSecure && useSecureObject) {
+        if (skipObject) {
+          client = new irc.Client('localhost', 'testbot');
+        } else if (isSecure && useSecureObject) {
           client = new irc.Client('notlocalhost', 'testbot', {
             secure: {
               host: 'localhost',
@@ -48,16 +50,20 @@ describe('Client', function() {
         });
       }
 
-      it('connects, registers and quits', function(done) {
-        runTests(done, false, false);
+      it('connects, registers and quits with basic config', function(done) {
+        runTests(done, false, false, false);
       });
 
-      it('connects, registers and quits, securely', function(done) {
-        runTests(done, true, false);
+      it('connects, registers and quits with secure boolean config', function(done) {
+        runTests(done, true, false, false);
       });
 
-      it('connects, registers and quits, securely, with secure object', function(done) {
-        runTests(done, true, true);
+      it('connects, registers and quits, with secure object config', function(done) {
+        runTests(done, true, true, false);
+      });
+
+      it('connects, registers and quits with no config', function(done) {
+        runTests(done, false, false, true);
       });
     });
 

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -153,24 +153,24 @@ describe('Client', function() {
       });
     });
 
-    function sendMotd(mock, nick, messages) {
-      messages = messages || ['Message'];
-      mock.send(':127.0.0.1 375 ' + nick + ' :- 127.0.0.1 Message of the Day -\r\n');
-      messages.forEach(function(line) {
-        mock.send(':127.0.0.1 372 ' + nick + ' :- ' + line + '\r\n');
-      });
-      mock.send(':127.0.0.1 376 ' + nick + ' :End of /MOTD command.\r\n');
-    }
-
-    function verifyMotd(client, motd, motdLines) {
-      var expected = '- 127.0.0.1 Message of the Day -\n';
-      expected += motdLines.map(function(x) { return '- ' + x; }).join('\n') + '\n';
-      expected += 'End of /MOTD command.\n';
-      expect(motd).to.equal(expected);
-      expect(client.motd).to.equal(expected);
-    }
-
     context('with motd', function() {
+      function sendMotd(mock, nick, messages) {
+        messages = messages || ['Message'];
+        mock.send(':127.0.0.1 375 ' + nick + ' :- 127.0.0.1 Message of the Day -\r\n');
+        messages.forEach(function(line) {
+          mock.send(':127.0.0.1 372 ' + nick + ' :- ' + line + '\r\n');
+        });
+        mock.send(':127.0.0.1 376 ' + nick + ' :End of /MOTD command.\r\n');
+      }
+
+      function verifyMotd(client, motd, motdLines) {
+        var expected = '- 127.0.0.1 Message of the Day -\n';
+        expected += motdLines.map(function(x) { return '- ' + x; }).join('\n') + '\n';
+        expected += 'End of /MOTD command.\n';
+        expect(motd).to.equal(expected);
+        expect(client.motd).to.equal(expected);
+      }
+
       function sharedTests() {
         it('emits motd', function(done) {
           var self = this;

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -367,7 +367,7 @@ describe('Client', function() {
       client.end();
       client.say('#channel', 'message3');
     }
-    expect(wrap).not.to.throw;
+    expect(wrap).not.to.throw();
   });
 
   it('handles topic-related events');

--- a/test/test-user-events.js
+++ b/test/test-user-events.js
@@ -347,6 +347,39 @@ describe('Client', function() {
       });
     });
 
+    describe('NOTICE', function() {
+      testHelpers.hookMockSetup(beforeEach, afterEach);
+      it('handles notice from user correctly', function(done) {
+        var self = this;
+
+        self.client.out.debug = sinon.spy();
+        self.client.on('notice', finish);
+        self.mock.send(':testbot2!~testbot2@EXAMPLE2.HOST NOTICE testbot :test message\r\n');
+
+        function finish(from, to, text, message) {
+          expect(from).to.equal('testbot2');
+          expect(to).to.equal('testbot');
+          expect(text).to.equal('test message');
+          expect(message).to.deep.equal({
+            prefix: 'testbot2!~testbot2@EXAMPLE2.HOST',
+            nick: 'testbot2',
+            user: '~testbot2',
+            host: 'EXAMPLE2.HOST',
+            command: 'NOTICE',
+            rawCommand: 'NOTICE',
+            commandType: 'normal',
+            args: ['testbot', 'test message']
+          });
+          setTimeout(function() {
+            expect(self.client.out.debug.args).to.deep.include(
+              ['GOT NOTICE from "testbot2": "test message"']
+            );
+            done();
+          }, 10);
+        }
+      });
+    });
+
     it('handles PRIVMSGs properly');
     it('handles INVITEs properly');
   });

--- a/test/test-user-events.js
+++ b/test/test-user-events.js
@@ -4,6 +4,22 @@ var expect = chai.expect;
 var sinon = require('sinon');
 
 describe('Client', function() {
+  function spyEvents(client, actual, expected, teardown, eventNames) {
+    eventNames.forEach(function(eventName) {
+      client.on(eventName, function() {
+        var args = Array.from(arguments);
+        args.unshift(eventName);
+        args = JSON.parse(JSON.stringify(args));
+        var lastArg = args[args.length-1];
+        if (typeof lastArg === 'object' && lastArg.prefix) {
+          args.pop(); // remove unnecessary `message`s
+        }
+        actual.push(args);
+        if (actual.length === expected.length) teardown();
+      });
+    });
+  }
+
   describe('user events', function() {
     context('with standard client', function() {
       testHelpers.hookMockSetup(beforeEach, afterEach);
@@ -20,31 +36,15 @@ describe('Client', function() {
           ['quit', 'user1', 'Quit: Leaving', ['#test', '#test2']],
           ['nick', 'user2', 'user4', ['#test']],
           ['nick', 'user3', 'user5', ['#test', '#test2']],
+          ['join', '#test', 'user6'],
+          ['kick', '#test', 'user6', 'user4', 'Test kick'],
           ['quit', 'user4', 'Quit: Leaving', ['#test']],
           ['part', '#test', 'user5', 'Bye'],
           ['quit', 'user5', 'See ya', ['#test2']]
         ];
         var actual = [];
 
-        function spyEvent(eventName) {
-          client.on(eventName, function() {
-            var args = Array.from(arguments);
-            args.unshift(eventName);
-            args = JSON.parse(JSON.stringify(args));
-            var lastArg = args[args.length-1];
-            if (typeof lastArg === 'object' && lastArg.prefix) {
-              args.pop(); // remove unnecessary `message`s
-            }
-            actual.push(args);
-            if (actual.length === expected.length) teardown();
-          });
-        }
-
-        spyEvent('join');
-        spyEvent('part');
-        spyEvent('quit');
-        spyEvent('names');
-        spyEvent('nick');
+        spyEvents(client, actual, expected, teardown, ['join', 'part', 'quit', 'names', 'nick', 'kick']);
 
         // welcome bot, give relevant prefix symbols
         mock.send(':localhost 311 testbot testbot ~testbot EXAMPLE.HOST * :testbot\r\n');
@@ -71,6 +71,12 @@ describe('Client', function() {
         mock.send(':user2!~user2@example.host NICK :user4\r\n');
         // user3 renames to user5 (#test, #test2)
         mock.send(':user3!~user3@example.host NICK :user5\r\n');
+
+        // #test: user6 joins
+        mock.send(':user6!~user6@example.host JOIN #test\r\n');
+        // #test: user6 is kicked by user4
+        mock.send(':user4!~user2@example.host KICK #test user6 :Test kick\r\n');
+
         // user4 quits (#test)
         mock.send(':user4!~user2@example.host QUIT :Quit: Leaving\r\n');
 
@@ -85,7 +91,119 @@ describe('Client', function() {
         }
       });
 
-      it('emits events both case-preserving and case-lowered where they differ');
+      it('emits events per fixtures with differing case', function(done) {
+        // client requests things around #Channel
+        // server responds with #cHannel
+        // expect responses of [event, event#cHannel, event#channel]
+        var mock = this.mock;
+        var client = this.client;
+
+        var expected = [
+          ['join', '#tEst', 'testbot'],
+          ['join#tEst', 'testbot'],
+          ['join#test', 'testbot'],
+
+          ['names', '#tEst', {testbot: '', user1: '', user2: '@', user3: ''}],
+          ['names#tEst', {testbot: '', user1: '', user2: '@', user3: ''}],
+          ['names#test', {testbot: '', user1: '', user2: '@', user3: ''}],
+
+          ['join', '#tEst2', 'testbot'],
+          ['join#tEst2', 'testbot'],
+          ['join#test2', 'testbot'],
+
+          ['names', '#tEst2', {testbot: '', user1: '', user3: ''}],
+          ['names#tEst2', {testbot: '', user1: '', user3: ''}],
+          ['names#test2', {testbot: '', user1: '', user3: ''}],
+
+          ['part', '#tEst', 'user1', 'Leaving'],
+          ['part#tEst', 'user1', 'Leaving'],
+          ['part#test', 'user1', 'Leaving'],
+
+          ['join', '#tEst', 'user1'],
+          ['join#tEst', 'user1'],
+          ['join#test', 'user1'],
+
+          ['quit', 'user1', 'Quit: Leaving', ['#test', '#test2']],
+          ['nick', 'user2', 'user4', ['#test']],
+          ['nick', 'user3', 'user5', ['#test', '#test2']],
+
+          ['join', '#tEst', 'user6'],
+          ['join#tEst', 'user6'],
+          ['join#test', 'user6'],
+
+          ['kick', '#tEst', 'user6', 'user4', 'Test kick'],
+          ['kick#tEst', 'user6', 'user4', 'Test kick'],
+          ['kick#test', 'user6', 'user4', 'Test kick'],
+
+          ['quit', 'user4', 'Quit: Leaving', ['#test']],
+
+          ['part', '#tEst', 'user5', 'Bye'],
+          ['part#tEst', 'user5', 'Bye'],
+          ['part#test', 'user5', 'Bye'],
+
+          ['quit', 'user5', 'See ya', ['#test2']]
+        ];
+        var actual = [];
+
+        spyEvents(client, actual, expected, teardown, [
+          'join',
+          'join#tEst', 'join#test',
+          'join#tEst2', 'join#test2',
+
+          'names',
+          'names#tEst', 'names#test',
+          'names#tEst2', 'names#test2',
+
+          'kick', 'kick#tEst', 'kick#test',
+          'part', 'part#tEst', 'part#test',
+
+          'quit', 'nick'
+        ]);
+
+        // welcome bot, give relevant prefix symbols
+        mock.send(':localhost 311 testbot testbot ~testbot EXAMPLE.HOST * :testbot\r\n');
+        mock.send(':localhost 005 testbot PREFIX=(qaohv)~&@%+ :are supported by this server\r\n');
+
+        // #test: testbot joins. users: testbot, user1, user2
+        client.join('#Test');
+        mock.send(':testbot!~testbot@EXAMPLE.HOST JOIN :#tEst\r\n');
+        mock.send(':localhost 353 testbot = #tEst :testbot user1 @user2 user3\r\n');
+        mock.send(':localhost 366 testbot #tEst :End of /NAMES list.\r\n');
+        // #test2: testbot joins. users: testbot, user1, user3
+        client.join('#Test2');
+        mock.send(':testbot!~testbot@EXAMPLE.HOST JOIN :#tEst2\r\n');
+        mock.send(':localhost 353 testbot = #tEst2 :testbot user1 user3\r\n');
+        mock.send(':localhost 366 testbot #tEst2 :End of /NAMES list.\r\n');
+
+        // #test: user1 parts, joins
+        mock.send(':user1!~user1@example.host PART #tEst :Leaving\r\n');
+        mock.send(':user1!~user1@example.host JOIN #tEst\r\n');
+
+        // user1 quits (#test, #test2)
+        mock.send(':user1!~user1@example.host QUIT :Quit: Leaving\r\n');
+        // user2 renames to user4 (#test)
+        mock.send(':user2!~user2@example.host NICK :user4\r\n');
+        // user3 renames to user5 (#test, #test2)
+        mock.send(':user3!~user3@example.host NICK :user5\r\n');
+
+        // #test: user6 joins
+        mock.send(':user6!~user6@example.host JOIN #tEst\r\n');
+        // #test: user6 is kicked by user4
+        mock.send(':user4!~user2@example.host KICK #tEst user6 :Test kick\r\n');
+
+        // user4 quits (#test)
+        mock.send(':user4!~user2@example.host QUIT :Quit: Leaving\r\n');
+
+        // #test: user5 parts
+        mock.send(':user5!~user3@example.host PART #tEst :Bye\r\n');
+        // user5 quits (#test2)
+        mock.send(':user5!~user3@example.host QUIT :See ya\r\n');
+
+        function teardown() {
+          expect(actual).to.deep.equal(expected);
+          done();
+        }
+      });
 
       it('handles self-events properly');
     });

--- a/test/test-user-events.js
+++ b/test/test-user-events.js
@@ -564,6 +564,30 @@ describe('Client', function() {
       });
     });
 
-    it('handles INVITEs properly');
+    describe('INVITE', function() {
+      testHelpers.hookMockSetup(beforeEach, afterEach);
+      it('handles invite from user correctly', function(done) {
+        var self = this;
+
+        self.client.on('invite', finish);
+        self.mock.send(':testbot2!~testbot2@EXAMPLE2.HOST INVITE testbot :#channel\r\n');
+
+        function finish(channel, from, message) {
+          expect(channel).to.equal('#channel');
+          expect(from).to.equal('testbot2');
+          expect(message).to.deep.equal({
+            prefix: 'testbot2!~testbot2@EXAMPLE2.HOST',
+            nick: 'testbot2',
+            user: '~testbot2',
+            host: 'EXAMPLE2.HOST',
+            command: 'INVITE',
+            rawCommand: 'INVITE',
+            commandType: 'normal',
+            args: ['testbot', '#channel']
+          });
+          done();
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
Per #29.

Fixes #41.

So far:

- [x] Re-add tests that `convert-encoding` does not throw when libraries are present (skipping when they're not)
- [x] Test that the bot responds to the right cyclingPingTimer events properly (stubbing cyclingPingTimer)
- [x] Test that channel events are emitted both as the channel name is given and in a lowercase format – this commit also fixes `names` to emit the lowercase version, which it didn't before
- [x] Test that error events are emitted by the client (or at least the "unknown command" error is emitted through that handler)
- [x] Test errors in `raw` are emitted through `error`
- [x] Test that `irc.Client` doesn't error with no given config
- [x] Test autoRenick stops when hitting renickCount (properly)
- [x] Test motd and auto-join of channels
- [x] Test TOPIC and receiving topic when joining channels
- [x] Test WHOIS on server connection
- [x] Test some parts of the API
- [x] Add "JOIN 0" and fix multi-channel JOIN/PARTs
- [x] Test NOTICE
- [x] Test PRIVMSG
- [x] Test INVITE