### PR TITLE
Fix client.join with a list of channel keys

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -148,6 +148,9 @@ Client
     ``channelList`` supports multiple channels in a comma-separated string (`as in the IRC protocol <https://tools.ietf.org/html/rfc2812#page-16>`_).
     The callback is called for each channel, but does not include the ``channel`` parameter (see the ``join#channel`` event).
 
+    To optionally send a list of keys (channel passwords) associated with each channel, add a space after the list of channels and append the list of channels.
+    For example: ``#foo,&bar fubar,foobar`` will join the channel ``#foo`` with the key ``fubar`` and the channel ``&bar`` with the key ``foobar``.
+
     Passing ``'0'`` to the ``channelList`` parameter will send ``JOIN 0`` to the server.
     As in the IRC spec, this will cause the client to part from all current channels.
     In such a case, the callback will not be called; you should instead bind to the ``part`` event to keep track of the progress made.

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1094,7 +1094,8 @@ Client.prototype.join = function(channelList, callback) {
             // Append to opts.channel on successful join, so it rejoins on reconnect.
             var chanString = channelName;
             if (keys && keys[index]) chanString += ' ' + keys[index];
-            if (self.opt.channels.indexOf(channelName) === -1 && self.opt.channels.indexOf(chanString) === -1) {
+            var channelIndex = self._findChannelFromStrings(channelName);
+            if (channelIndex === -1) {
                 self.opt.channels.push(chanString);
             }
 
@@ -1119,8 +1120,9 @@ Client.prototype.part = function(channelList, message, callback) {
       }
 
       // remove this channel from this.opt.channels so we won't rejoin upon reconnect
-      if (self.opt.channels.indexOf(channelName) !== -1) {
-          self.opt.channels.splice(self.opt.channels.indexOf(channelName), 1);
+      var channelIndex = self._findChannelFromStrings(channelName);
+      if (channelIndex !== -1) {
+          self.opt.channels.splice(channelIndex, 1);
       }
     });
 
@@ -1146,6 +1148,17 @@ Client.prototype.action = function(target, text) {
             });
         });
     }
+};
+
+// finds the string in opt.channels representing channelName (if present)
+Client.prototype._findChannelFromStrings = function(channelName) {
+    channelName = channelName.toLowerCase();
+    var index = this.opt.channels.findIndex(function(listString) {
+      var name = listString.split(' ')[0]; // ignore the key in the string
+      name = name.toLowerCase(); // check case-insensitively
+      return channelName === name;
+    });
+    return index;
 };
 
 Client.prototype._splitLongLines = function(words, maxLength, destination) {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -691,11 +691,11 @@ function Client(server, clientNick, opt) {
 
     self.addListener('kick', function(channel, nick) {
         if (self.opt.autoRejoin && nick.toLowerCase() === self.nick.toLowerCase())
-            self.send('JOIN', channel);
+            self.join(channel);
     });
     self.addListener('motd', function() {
         self.opt.channels.forEach(function(channel) {
-            self.send('JOIN', channel);
+            self.join(channel);
         });
     });
 
@@ -1086,13 +1086,16 @@ Client.prototype.join = function(channelList, callback) {
     var self = this;
     var parts = channelList.split(' ');
     var channels = parts[0];
-    // var keys = parts[1];
+    var keys;
+    if (parts[1]) keys = parts[1].split(',');
     channels = channels.split(',');
-    channels.forEach(function(channelName) {
+    channels.forEach(function(channelName, index) {
         self.once('join' + channelName.toLowerCase(), function() {
             // Append to opts.channel on successful join, so it rejoins on reconnect.
-            if (self.opt.channels.indexOf(channelName) === -1) {
-                self.opt.channels.push(channelName);
+            var chanString = channelName;
+            if (keys && keys[index]) chanString += ' ' + keys[index];
+            if (self.opt.channels.indexOf(channelName) === -1 && self.opt.channels.indexOf(chanString) === -1) {
+                self.opt.channels.push(chanString);
             }
 
             if (typeof callback === 'function') {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1084,7 +1084,10 @@ Client.prototype.cancelAutoRenick = function() {
 
 Client.prototype.join = function(channelList, callback) {
     var self = this;
-    var channels = channelList.split(',');
+    var parts = channelList.split(' ');
+    var channels = parts[0];
+    // var keys = parts[1];
+    channels = channels.split(',');
     channels.forEach(function(channelName) {
         self.once('join' + channelName.toLowerCase(), function() {
             // Append to opts.channel on successful join, so it rejoins on reconnect.
@@ -1097,7 +1100,7 @@ Client.prototype.join = function(channelList, callback) {
             }
         });
     });
-    self.send('JOIN', channelList);
+    self.send.apply(this, ['JOIN'].concat(channelList.split(' ')));
 };
 
 Client.prototype.part = function(channelList, message, callback) {

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -293,7 +293,12 @@ describe('Client', function() {
         }
 
         function end() {
-          expect(downcaseChannels(self.client.opt.channels)).to.deep.equal(downcaseChannels(channels));
+          var expected = downcaseChannels(channels);
+          expected = expected.map(function(x, index) {
+            if (index === 0) return x;
+            return x + ' key';
+          });
+          expect(downcaseChannels(self.client.opt.channels)).to.deep.equal(expected);
           done();
         }
       });

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -217,7 +217,7 @@ describe('Client', function() {
       }
 
       context('with opt.channels', function() {
-        testHelpers.hookMockSetup(beforeEach, afterEach, {client: {channels: ['#test', '#test2']}});
+        testHelpers.hookMockSetup(beforeEach, afterEach, {client: {channels: ['#test', '#test2', '#test3 password']}});
 
         sharedTests();
 
@@ -226,7 +226,7 @@ describe('Client', function() {
         });
 
         it('joins specified channels on motd', function(done) {
-          var expected = [['JOIN #test'], ['JOIN #test2']];
+          var expected = [['JOIN #test'], ['JOIN #test2'], ['JOIN #test3 password']];
           var self = this;
           sendMotd(self.mock, 'testbot');
           self.client.on('motd', function() {

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -881,6 +881,40 @@ describe('Client', function() {
     });
   });
 
+  describe('_findChannelFromStrings', function() {
+    testHelpers.hookMockSetup(beforeEach, afterEach);
+
+    it('detects channels in opt.channels', function() {
+      this.client.opt.channels = ['#chan2', '#chan3'];
+      expect(this.client._findChannelFromStrings('#chan')).to.equal(-1);
+      expect(this.client._findChannelFromStrings('#chan2')).to.equal(0);
+      expect(this.client._findChannelFromStrings('#chan3')).to.equal(1);
+    });
+
+    it('detects case-insensitively', function() {
+      this.client.opt.channels = ['#Chan2', '#Chan3'];
+      expect(this.client._findChannelFromStrings('#chan')).to.equal(-1);
+      expect(this.client._findChannelFromStrings('#chan2')).to.equal(0);
+      expect(this.client._findChannelFromStrings('#chan3')).to.equal(1);
+
+      this.client.opt.channels = ['#chan2', '#chan3'];
+      expect(this.client._findChannelFromStrings('#Chan')).to.equal(-1);
+      expect(this.client._findChannelFromStrings('#Chan2')).to.equal(0);
+      expect(this.client._findChannelFromStrings('#Chan3')).to.equal(1);
+    });
+
+    it('ignores keys', function() {
+      this.client.opt.channels = ['#chan2 key2', '#Chan3 key3'];
+      expect(this.client._findChannelFromStrings('#chan')).to.equal(-1);
+      expect(this.client._findChannelFromStrings('#chan2')).to.equal(0);
+      expect(this.client._findChannelFromStrings('#chan3')).to.equal(1);
+
+      expect(this.client._findChannelFromStrings('#Chan')).to.equal(-1);
+      expect(this.client._findChannelFromStrings('#Chan2')).to.equal(0);
+      expect(this.client._findChannelFromStrings('#Chan3')).to.equal(1);
+    });
+  });
+
   describe('unhandled messages', function() {
     testHelpers.hookMockSetup(beforeEach, afterEach, {client: {server: '127.0.0.1'}});
     specify('are emitted appropriately', function(done) {


### PR DESCRIPTION
This was erroneously broken in d15c7a1. It should be possible to call join('#foo bar') to join the channel #foo with the channel key bar, which this re-enables.

It is similarly broken with the auto-join using `opt.channels`, but this is fixed here by calling the internal `join` method to join those channels (as opposed to directly sending a `JOIN` message for each), which should not change the behavior.

This PR also cleans up some logic that checks whether a channel is already in `opt.channels` – see the new `_findChannelFromStrings` method – and clarifies in the documentation that this feature (being able to send keys with `client.join`) is intended (and supported) behavior.