### PR TITLE
Allow requesting IRCv3 extended-join capability

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -68,7 +68,8 @@ function Client(server, clientNick, opt) {
         encoding: null,
         millisecondsOfSilenceBeforePingSent: 15 * 1000,
         millisecondsBeforePingTimeout: 8 * 1000,
-        enableStrictParse: false
+        enableStrictParse: false,
+        extendedJoin: false
     };
 
     // Features supported by the server
@@ -633,6 +634,13 @@ function Client(server, clientNick, opt) {
                 // currently only handle ACK sasl responses
                 if (message.args[1] !== 'ACK') break;
                 var caps = message.args[2].split(/\s+/);
+
+                if (!this.opt.sasl && caps.indexOf('extended-join') {
+                    // send CAP END if we requested extended-join and don't need to do sasl authentication
+                    self.send('CAP', 'END');
+                    break;
+                }
+
                 if (caps.indexOf('sasl') < 0) break;
 
                 self.send('AUTHENTICATE', 'PLAIN');
@@ -751,6 +759,10 @@ Client.prototype._connectionHandler = function() {
     // WEBIRC
     if (this.opt.webirc.ip && this.opt.webirc.pass && this.opt.webirc.host) {
         this.send('WEBIRC', this.opt.webirc.pass, this.opt.userName, this.opt.webirc.host, this.opt.webirc.ip);
+    }
+    
+    if (this.opt.extendedJoin) {
+        this.send('CAP', 'REQ', 'extended-join');
     }
 
     // SASL, server password

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -635,7 +635,7 @@ function Client(server, clientNick, opt) {
                 if (message.args[1] !== 'ACK') break;
                 var caps = message.args[2].split(/\s+/);
 
-                if (!this.opt.sasl && caps.indexOf('extended-join') {
+                if (!this.opt.sasl && caps.indexOf('extended-join')) {
                     // send CAP END if we requested extended-join and don't need to do sasl authentication
                     self.send('CAP', 'END');
                     break;


### PR DESCRIPTION
Standard IRC `JOIN` messages look like this:
```
:nick!ident@host JOIN #channelname
```

IRCv3 `JOIN` messages look like this:
```
:nick!ident@host JOIN #channelname * :Fusl
```
or
```
:nick!ident@host JOIN #channelname authenticated-username :Fusl
```

`message.args[1]` will be the authenticated username and `message.args[2]` the real name.